### PR TITLE
Update deprecated function

### DIFF
--- a/rdoasis/settings.py
+++ b/rdoasis/settings.py
@@ -21,7 +21,7 @@ class RdoasisMixin(ResonantGeoDataBaseMixin, ConfigMixin):
     BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
 
     @staticmethod
-    def before_binding(configuration: ComposedConfiguration) -> None:
+    def mutate_configuration(configuration: ComposedConfiguration) -> None:
         # Install local apps first, to ensure any overridden resources are found first
         configuration.INSTALLED_APPS = [
             'rdoasis.core.apps.CoreConfig',

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'rules',
         'zipstream==1.1.4',
         # Production-only
-        'django-composed-configuration[prod]',
+        'django-composed-configuration[prod]>=0.19.2',
         'django-s3-file-field[boto3]',
         'gunicorn',
         # RGD
@@ -65,7 +65,7 @@ setup(
     dependency_links=['https://girder.github.io/large_image_wheels'],
     extras_require={
         'dev': [
-            'django-composed-configuration[dev]',
+            'django-composed-configuration[dev]>=0.19.2',
             'django-debug-toolbar',
             'django-s3-file-field[minio]',
             'ipython',


### PR DESCRIPTION
`before_binding` has been deprecated in favor of `mutate_configuration` in `django-composed-configurations`.