### PR TITLE
Pin docker services

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgis/postgis:latest
+        image: postgis/postgis:13-3.2
         env:
           POSTGRES_DB: django
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
       rabbitmq:
-        image: rabbitmq:management
+        image: rabbitmq:3.9.13-management
         ports:
           - 5672:5672
       minio:
         # This image does not require any command arguments (which GitHub Actions don't support)
-        image: bitnami/minio:latest
+        image: bitnami/minio:2022.3.5-debian-10-r3
         env:
           MINIO_ACCESS_KEY: minioAccessKey
           MINIO_SECRET_KEY: minioSecretKey

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -25,8 +25,8 @@ jobs:
         # This image does not require any command arguments (which GitHub Actions don't support)
         image: bitnami/minio:2022.3.5-debian-10-r3
         env:
-          MINIO_ACCESS_KEY: minioAccessKey
-          MINIO_SECRET_KEY: minioSecretKey
+          MINIO_ROOT_USER: minioAccessKey
+          MINIO_ROOT_PASSWORD: minioSecretKey
         ports:
           - 9000:9000
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: postgis/postgis:13-3.1
+    image: postgis/postgis:13-3.2
     environment:
       POSTGRES_DB: django
       POSTGRES_PASSWORD: postgres
@@ -16,7 +16,7 @@ services:
       - ${DOCKER_RABBITMQ_PORT-5672}:5672
 
   minio:
-    image: minio/minio:RELEASE.2022-03-03T21-21-16Z
+    image: bitnami/minio:2022.3.5-debian-10-r3
     # When run with a TTY, minio prints credentials on startup
     tty: true
     command: ["server", "/data", "--console-address", ":${DOCKER_MINIO_CONSOLE_PORT-9001}"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: postgis/postgis:latest
+    image: postgis/postgis:13-3.1
     environment:
       POSTGRES_DB: django
       POSTGRES_PASSWORD: postgres
@@ -11,18 +11,18 @@ services:
       - dbdata:/var/lib/postgresql/data
 
   rabbitmq:
-    image: rabbitmq:management
+    image: rabbitmq:3.9.13-management
     ports:
       - ${DOCKER_RABBITMQ_PORT-5672}:5672
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2022-03-03T21-21-16Z
     # When run with a TTY, minio prints credentials on startup
     tty: true
     command: ["server", "/data", "--console-address", ":${DOCKER_MINIO_CONSOLE_PORT-9001}"]
     environment:
-      MINIO_ACCESS_KEY: minioAccessKey
-      MINIO_SECRET_KEY: minioSecretKey
+      MINIO_ROOT_USER: minioAccessKey
+      MINIO_ROOT_PASSWORD: minioSecretKey
     ports:
       - ${DOCKER_MINIO_PORT-9000}:9000
       - ${DOCKER_MINIO_CONSOLE_PORT-9001}:9001


### PR DESCRIPTION
Pins the docker services to the tags I have running locally

This does not add any routines to auto bump these docker services as I figured these can be changed manually.